### PR TITLE
Improve CLI fallback and summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,9 @@ daily-budget-tracker/
 2. 必要ライブラリをインストール：
 
 ```bash
-pip install pandas openpyxl
+pip install pandas openpyxl jpholiday
 ```
+※Tkinter が入っていない環境では別途 `python3-tk` パッケージのインストールが必要です。
 
 3. スクリプトを実行：
 

--- a/forecast_generator.py
+++ b/forecast_generator.py
@@ -1,26 +1,44 @@
-import pandas as pd
-import openpyxl
-from openpyxl.styles import PatternFill, Font
-from openpyxl.utils.dataframe import dataframe_to_rows
-from openpyxl.formatting.rule import FormulaRule
+"""予算・FC・実績を横並びで比較するExcelを生成するスクリプト."""
+
+from __future__ import annotations
+
+import datetime
+import re
 import tkinter as tk
 from tkinter import filedialog, simpledialog
-import calendar
-import datetime
+
 import jpholiday
+import pandas as pd
+from openpyxl import Workbook
+from openpyxl.formatting.rule import FormulaRule
+from openpyxl.styles import Font, PatternFill
+from openpyxl.utils import get_column_letter
+from openpyxl.utils.dataframe import dataframe_to_rows
 
 # === GUIでキャパシティと期首月の取得 ===
-root = tk.Tk()
-root.withdraw()
-capacity = simpledialog.askinteger("キャパシティ入力", "客室キャパシティ（部屋数）を入力してください：")
-start_month = simpledialog.askinteger("期首月入力", "期首月（例：1〜12）を入力してください：")
-file_path = filedialog.askopenfilename(title="日別予算Excelファイルを選択")
 
+try:
+    root = tk.Tk()
+    root.withdraw()
+    capacity = simpledialog.askinteger(
+        "キャパシティ入力",
+        "客室キャパシティ（部屋数）を入力してください：",
+    )
+    start_month = simpledialog.askinteger(
+        "期首月入力",
+        "期首月（例：1〜12）を入力してください：",
+    )
+    file_path = filedialog.askopenfilename(title="日別予算Excelファイルを選択")
+except tk.TclError:
+    print("GUI を起動できないため CLI モードで実行します。")
+    capacity = int(input("キャパシティ（部屋数）: "))
+    start_month = int(input("期首月 (1-12): "))
+    file_path = input("日別予算Excelファイルのパス: ")
 # === Excel読み込み ===
 xls = pd.read_excel(file_path, sheet_name=None)
 
 # === 出力用Excel作成 ===
-wb = openpyxl.Workbook()
+wb = Workbook()
 wb.remove(wb.active)
 
 # === 曜日装飾 ===
@@ -30,92 +48,161 @@ sun_fill = PatternFill(start_color="FFE5E5", end_color="FFE5E5", fill_type="soli
 sun_font = Font(color="990000")
 gray_fill = PatternFill(start_color="DDDDDD", end_color="DDDDDD", fill_type="solid")
 
-# === 各月シート作成 ===
+# --- 各月シート作成 ---
+summary_dict: dict[tuple[int, int], list[float]] = {}
 for sheet_name, df in xls.items():
     if not isinstance(df, pd.DataFrame) or df.empty:
         continue
 
-    df['日付'] = pd.to_datetime(df['日付'], errors='coerce')
-    df = df.dropna(subset=['日付'])
+    df["日付"] = pd.to_datetime(df["日付"], errors="coerce")
+    df = df.dropna(subset=["日付"])
+    if df.empty:
+        continue
 
-    # 日付ごとに横持ち1行
-    rows = []
-    for date in df['日付'].dt.date.unique():
-        weekday = date.weekday()
-        weekday_jp = ['月', '火', '水', '木', '金', '土', '日'][weekday]
+    year = int(df["日付"].dt.year.iloc[0])
+    month = int(df["日付"].dt.month.iloc[0])
+    ws = wb.create_sheet(title=f"{year}年{month}月")
+
+    # 日付ごとに横持ち化
+    rows: list[dict] = []
+    for date, g in df.groupby(df["日付"].dt.date):
+        weekday_jp = ["月", "火", "水", "木", "金", "土", "日"][date.weekday()]
         if jpholiday.is_holiday(date):
-            weekday_jp = '祝'
-        base = {'日付': date.strftime('%Y/%m/%d'), '曜日': weekday_jp}
-        for kind in ['予算', 'FC', '実績']:
-            subset = df[(df['日付'] == pd.Timestamp(date)) & (df['種別'] == kind)]
-            if not subset.empty:
-                row = subset.iloc[0]
-                base[f'室数_{kind}'] = row['室数']
-                base[f'人数_{kind}'] = row['人数']
-                base[f'宿泊売上_{kind}'] = row['宿泊売上']
+            weekday_jp = "祝"
+
+        base = {"日付": date.strftime("%Y/%m/%d"), "曜日": weekday_jp}
+        for kind in ["予算", "FC", "実績"]:
+            sub = g[g["種別"] == kind]
+            if not sub.empty:
+                r = sub.iloc[0]
+                base[f"室数_{kind}"] = r["室数"]
+                base[f"人数_{kind}"] = r["人数"]
+                base[f"宿泊売上_{kind}"] = r["宿泊売上"]
         rows.append(base)
 
     df_out = pd.DataFrame(rows)
 
-    # 数式列を追加
-    for kind in ['予算', 'FC', '実績']:
-        df_out[f'OCC_{kind}'] = ''
-        df_out[f'ADR_{kind}'] = ''
-        df_out[f'DOR_{kind}'] = ''
-        df_out[f'RevPAR_{kind}'] = ''
+    # 列順を定義
+    metrics = ["室数", "人数", "宿泊売上", "OCC", "ADR", "DOR", "RevPAR"]
+    cols = ["日付", "曜日"]
+    for kind in ["予算", "FC", "実績"]:
+        cols += [f"{m}_{kind}" for m in metrics]
+    cols += [
+        "差_OCC_FC-予算",
+        "差_ADR_FC-予算",
+        "差_売上_FC-予算",
+        "差_OCC_実績-FC",
+        "差_ADR_実績-FC",
+        "差_売上_実績-FC",
+    ]
+    for c in cols:
+        if c not in df_out.columns:
+            df_out[c] = ""
+    df_out = df_out.reindex(columns=cols)
 
-    # 差異列
-    df_out['差_OCC_FC-予算'] = ''
-    df_out['差_ADR_FC-予算'] = ''
-    df_out['差_売上_FC-予算'] = ''
-    df_out['差_OCC_実績-FC'] = ''
-    df_out['差_ADR_実績-FC'] = ''
-    df_out['差_売上_実績-FC'] = ''
-
-    # Excelシートへ出力
-    ws = wb.create_sheet(title=sheet_name)
+    # 出力
     for r in dataframe_to_rows(df_out, index=False, header=True):
         ws.append(r)
 
-    # 曜日装飾（色分け）
-    for row in ws.iter_rows(min_row=2, max_row=ws.max_row, min_col=1, max_col=2):
-        date_cell, weekday_cell = row
+    header_map = {c.value: i for i, c in enumerate(ws[1], start=1)}
+    for row in range(2, ws.max_row + 1):
+        for kind in ["予算", "FC", "実績"]:
+            room_c = get_column_letter(header_map[f"室数_{kind}"])
+            pax_c = get_column_letter(header_map[f"人数_{kind}"])
+            sales_c = get_column_letter(header_map[f"宿泊売上_{kind}"])
+            occ_c = ws.cell(row=row, column=header_map[f"OCC_{kind}"])
+            adr_c = ws.cell(row=row, column=header_map[f"ADR_{kind}"])
+            dor_c = ws.cell(row=row, column=header_map[f"DOR_{kind}"])
+            rev_c = ws.cell(row=row, column=header_map[f"RevPAR_{kind}"])
+
+            occ_c.value = f"={room_c}{row}/{capacity}"
+            adr_c.value = f"={sales_c}{row}/{pax_c}{row}"
+            dor_c.value = f"={pax_c}{row}/{room_c}{row}"
+            rev_c.value = f"={sales_c}{row}/{capacity}"
+
+            occ_c.number_format = "0.0%"
+            adr_c.number_format = "#,##0"
+            dor_c.number_format = "0.00"
+            rev_c.number_format = "#,##0"
+
+        # 差異列
+        ws.cell(row=row, column=header_map["差_OCC_FC-予算"]).value = (
+            f"={get_column_letter(header_map['OCC_FC'])}{row}-"
+            f"{get_column_letter(header_map['OCC_予算'])}{row}"
+        )
+        ws.cell(row=row, column=header_map["差_ADR_FC-予算"]).value = (
+            f"={get_column_letter(header_map['ADR_FC'])}{row}-"
+            f"{get_column_letter(header_map['ADR_予算'])}{row}"
+        )
+        ws.cell(row=row, column=header_map["差_売上_FC-予算"]).value = (
+            f"={get_column_letter(header_map['宿泊売上_FC'])}{row}-"
+            f"{get_column_letter(header_map['宿泊売上_予算'])}{row}"
+        )
+        ws.cell(row=row, column=header_map["差_OCC_実績-FC"]).value = (
+            f"={get_column_letter(header_map['OCC_実績'])}{row}-"
+            f"{get_column_letter(header_map['OCC_FC'])}{row}"
+        )
+        ws.cell(row=row, column=header_map["差_ADR_実績-FC"]).value = (
+            f"={get_column_letter(header_map['ADR_実績'])}{row}-"
+            f"{get_column_letter(header_map['ADR_FC'])}{row}"
+        )
+        ws.cell(row=row, column=header_map["差_売上_実績-FC"]).value = (
+            f"={get_column_letter(header_map['宿泊売上_実績'])}{row}-"
+            f"{get_column_letter(header_map['宿泊売上_FC'])}{row}"
+        )
+
+        # 曜日装飾
+        w_cell = ws.cell(row=row, column=header_map["曜日"])
+        date_cell = ws.cell(row=row, column=header_map["日付"])
         try:
-            date_obj = datetime.datetime.strptime(date_cell.value, "%Y/%m/%d").date()
+            d_obj = datetime.datetime.strptime(str(date_cell.value), "%Y/%m/%d").date()
         except Exception:
             continue
+        if jpholiday.is_holiday(d_obj) or w_cell.value in ["日", "祝"]:
+            w_cell.fill = sun_fill
+            w_cell.font = sun_font
+        elif w_cell.value == "土":
+            w_cell.fill = sat_fill
+            w_cell.font = sat_font
 
-        if jpholiday.is_holiday(date_obj) or weekday_cell.value in ['日', '祝']:
-            weekday_cell.fill = sun_fill
-            weekday_cell.font = sun_font
-        elif weekday_cell.value == '土':
-            weekday_cell.fill = sat_fill
-            weekday_cell.font = sat_font
-
-    # 実績が入力されていたら、FC欄をグレー化（条件付き書式）
-    headers = [cell.value for cell in ws[1]]
-    for i, col in enumerate(headers):
-        if col == '室数_FC':
-            fc_col = openpyxl.utils.get_column_letter(i+1)
-        if col == '室数_実績':
-            actual_col = openpyxl.utils.get_column_letter(i+1)
-
-    formula = f'LEN(${actual_col}2)>0'
-    for i in range(0, 7):  # 室数〜RevPARまでの列
-        col_letter = openpyxl.utils.get_column_letter(openpyxl.utils.column_index_from_string(fc_col) + i)
+    # 実績入力時にFC列をグレー化
+    fc_col = get_column_letter(header_map["室数_FC"])
+    actual_col = get_column_letter(header_map["室数_実績"])
+    formula = f"LEN(${actual_col}2)>0"
+    for offset in range(0, 7):
+        col_letter = get_column_letter(header_map["室数_FC"] + offset)
         rule = FormulaRule(formula=[formula], fill=gray_fill)
-        ws.conditional_formatting.add(f"{col_letter}2:{col_letter}{ws.max_row}", rule)
+        ws.conditional_formatting.add(
+            f"{col_letter}2:{col_letter}{ws.max_row}", rule
+        )
+
+    # 月次合計を集計
+    sales_budget = df[df["種別"] == "予算"]["宿泊売上"].sum()
+    sales_fc = df[df["種別"] == "FC"]["宿泊売上"].sum()
+    sales_actual = df[df["種別"] == "実績"]["宿泊売上"].sum()
+    summary_dict[(year, month)] = [sales_budget, sales_fc, sales_actual]
 
 # === 年間集計シート ===
 summary = wb.create_sheet(title="年間集計")
-summary.append(['月', '予算_売上', 'FC_売上', '実績_売上'])
-month_order = [(start_month + i - 1) % 12 + 1 for i in range(12)]
-for m in month_order:
-    month_label = f"{m}月"
-    summary.append([month_label, '', '', ''])
+summary.append(["月", "予算_売上", "FC_売上", "実績_売上"])
+match = re.search(r"(20\d{2})", file_path)
+start_year = int(match.group(1)) if match else datetime.date.today().year
+year = start_year
+month = start_month
+for _ in range(12):
+    label = f"{year}年{month}月"
+    budget, fc, actual = summary_dict.get((year, month), [0, 0, 0])
+    summary.append([label, budget, fc, actual])
+    if month == 12:
+        month = 1
+        year += 1
+    else:
+        month += 1
 
 # === 保存 ===
-year_str = ''.join(filter(str.isdigit, file_path))
+match = re.search(r"(20\d{2})", file_path)
+year_str = match.group(1) if match else str(datetime.date.today().year)
 out_path = f"予実管理表_{year_str}年度.xlsx"
 wb.save(out_path)
 print(f"✅ 出力完了: {out_path}")
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 pandas
 openpyxl
-tk
 jpholiday


### PR DESCRIPTION
## Summary
- add CLI fallback when tkinter GUI fails
- show 12-month summary starting from specified fiscal month
- document jpholiday and tkinter install steps

## Testing
- `python -m py_compile forecast_generator.py`


------
https://chatgpt.com/codex/tasks/task_e_684cc771142c832dab280610152f7f91