### PR TITLE
Fix missing variable end_row in forecast_generator

### DIFF
--- a/forecast_generator.py
+++ b/forecast_generator.py
@@ -692,6 +692,7 @@ for title, left, right, fill in blocks:
             year += 1
         else:
             month += 1
+    end_row = header_row + 12
     total_row = end_row + 1
     variance.cell(row=total_row, column=1, value="年間合計")
     for idx, m in enumerate(metrics, start=2):


### PR DESCRIPTION
## Summary
- define `end_row` when creating variance sheet

## Testing
- `python -m py_compile forecast_generator.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ca5dc7178832db2933bb88a995c5a